### PR TITLE
Support NodeJS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,6 +91,7 @@ gulp.task( 'bundle-loader-support', [ 'bundle-objloader2' ], function() {
 			'src/loaders/support/LoaderCommons.js',
 			'src/loaders/support/LoaderBuilder.js',
 			'src/loaders/support/LoaderWorkerSupport.js',
+			'src/loaders/support/NodeLoaderWorkerSupport.js',
 			'src/loaders/support/LoaderWorkerDirector.js'
 		]
 	)
@@ -134,6 +135,7 @@ gulp.task( 'create-docs', function ( cb ) {
 				'src/loaders/support/LoaderCommons.js',
 				'src/loaders/support/LoaderBuilder.js',
 				'src/loaders/support/LoaderWorkerSupport.js',
+				'src/loaders/support/NodeLoaderWorkerSupport.js',
 				'src/loaders/support/LoaderWorkerDirector.js',
 				'src/loaders/OBJLoader2.js'
 			],

--- a/src/loaders/support/LoaderWorkerSupport.js
+++ b/src/loaders/support/LoaderWorkerSupport.js
@@ -151,6 +151,11 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 		};
 
 		LoaderWorker.prototype.initWorker = function ( code, runnerImplName ) {
+			var supportError = LoaderWorker.checkSupport();
+			if(supportError) {
+				throw supportError;
+			}
+
 			this.runnerImplName = runnerImplName;
 
 			var blob = new Blob( [ code ], { type: 'application/javascript' } );
@@ -299,12 +304,9 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 			debug: false
 		};
 
-		var supportError = LoaderWorker.checkSupport();
-		if(supportError) {
-			throw supportError;
-		}
-
-		this.loaderWorker = new LoaderWorker();
+		//Choose implementation of worker based on environment
+		this.loaderWorker = typeof "window" === undefined ? new LoaderWorker()
+			: new THREE.NodeLoaderWorker();
 	}
 
 	/**

--- a/src/loaders/support/LoaderWorkerSupport.js
+++ b/src/loaders/support/LoaderWorkerSupport.js
@@ -355,11 +355,16 @@ THREE.LoaderSupport.WorkerSupport = (function () {
 
 			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using "' + runnerImpl.name + '" as Runner class for worker.' );
 
-		} else {
+		} else if ( typeof "window" !== undefined ) { //Browser implementation
 
 			runnerImpl = THREE.LoaderSupport.WorkerRunnerRefImpl;
 			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using DEFAULT "THREE.LoaderSupport.WorkerRunnerRefImpl" as Runner class for worker.' );
 
+		} else { //NodeJS implementation
+
+			runnerImpl = THREE.LoaderSupport.NodeWorkerRunnerRefImpl;
+			if ( this.logging.enabled ) console.info( 'WorkerSupport: Using DEFAULT "THREE.LoaderSupport.NodeWorkerRunnerRefImpl" as Runner class for worker.' );
+		
 		}
 
 		var userWorkerCode = functionCodeBuilder( buildObject, buildSingleton );

--- a/src/loaders/support/NodeLoaderWorkerSupport.js
+++ b/src/loaders/support/NodeLoaderWorkerSupport.js
@@ -1,0 +1,80 @@
+var _require = eval('require'); //Work around webpack builds failing with NodeJS requires
+
+/**
+ * This class provides the NodeJS implementation of the WorkerRunnerRefImpl
+ * @class
+ * @extends THREE.LoaderSupport.WorkerRunnerRefImpl
+ */
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl = (function(){
+	function NodeWorkerRunnerRefImpl(){
+		//No call to super because super class only binds to processMessage
+		//In NodeJS, there is no addEventListener so use onmessage.
+		//Also, the message object can be passed directly to
+		//processMessage() as it isn't an `Event`, but a plain object
+		//with the data
+		this.getParentScope().onmessage = this.processMessage(this);
+	}
+	//Inherit from WorkerRunnerRefImpl
+	Object.setPrototypeOf(NodeWorkerRunnerRefImpl.prototype,
+		THREE.LoaderSupport.WorkerRunnerRefImpl);
+
+	/**
+	 * @inheritdoc
+	 * @memberOf THREE.LoaderSupport.NodeWorkerRunnerRefImpl
+	 * 
+	 * @returns {MessagePort} NodeJS object that's similar to
+	 * GlobalWorkerScope
+	 */
+	NodeWorkerRunnerRefImpl.prototype.getParentScope = function(){
+		return _require("worker_threads").parentPort;
+	}
+
+	return NodeWorkerRunnerRefImpl;
+})();
+
+/**
+ * This class provides the NodeJS implementation of LoaderWorker
+ * @class
+ * @extends THREE.LoaderSupport.LoaderWorker
+ */
+THREE.LoaderSupport.NodeLoaderWorker = (function(){
+	function NodeLoaderWorker(){
+		LoaderWorker.call(this); //call super class
+	}
+	//Inherit from LoaderWorker
+	Object.setPrototypeOf(NodeLoaderWorker.prototype, LoaderWorker);
+
+	/**
+	 * @inheritdoc
+	 * @memberOf THREE.LoaderSupport.NodeLoaderWorker
+	 */
+	NodeLoaderWorker.checkSupport = function() {
+		try {
+			_require.resolve("worker_threads");
+		}
+		catch(e) {
+			return "This version of Node does not support web workers!";
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 * @memberOf THREE.LoaderSupport.NodeLoaderWorker
+	 */
+	NodeLoaderWorker.prototype.initWorker = function ( code, runnerImplName ) {
+		this.runnerImplName = runnerImplName;
+
+		var Worker = _require("worker_threads").Worker;
+		this.worker = new Worker(code, {eval: true});
+
+		this.worker.onmessage = this._receiveWorkerMessage;
+
+		// set referemce to this, then processing in worker scope within "_receiveWorkerMessage" can access members
+		this.worker.runtimeRef = this;
+
+		// process stored queuedMessage
+		this._postMessage();
+	}
+
+	return NodeLoaderWorker;
+})();

--- a/src/loaders/support/NodeLoaderWorkerSupport.js
+++ b/src/loaders/support/NodeLoaderWorkerSupport.js
@@ -62,6 +62,11 @@ THREE.LoaderSupport.NodeLoaderWorker = (function(){
 	 * @memberOf THREE.LoaderSupport.NodeLoaderWorker
 	 */
 	NodeLoaderWorker.prototype.initWorker = function ( code, runnerImplName ) {
+		var supportError = NodeLoaderWorker.checkSupport();
+		if(supportError) {
+			throw supportError;
+		}
+			
 		this.runnerImplName = runnerImplName;
 
 		var Worker = _require("worker_threads").Worker;

--- a/src/loaders/support/NodeLoaderWorkerSupport.js
+++ b/src/loaders/support/NodeLoaderWorkerSupport.js
@@ -1,85 +1,35 @@
-var _require = eval('require'); //Work around webpack builds failing with NodeJS requires
+//Work around webpack builds failing with NodeJS requires
+var _require = eval( 'require' );
 
 /**
  * This class provides the NodeJS implementation of the WorkerRunnerRefImpl
  * @class
  * @extends THREE.LoaderSupport.WorkerRunnerRefImpl
  */
-THREE.LoaderSupport.NodeWorkerRunnerRefImpl = (function(){
-	function NodeWorkerRunnerRefImpl(){
+THREE.LoaderSupport.NodeWorkerRunnerRefImpl = ( function(){
+
+	function NodeWorkerRunnerRefImpl () {
 		//No call to super because super class only binds to processMessage
 		//In NodeJS, there is no addEventListener so use onmessage.
 		//Also, the message object can be passed directly to
 		//processMessage() as it isn't an `Event`, but a plain object
 		//with the data
-		this.getParentScope().onmessage = this.processMessage(this);
+		this.getParentScope().onmessage = this.processMessage( this );
 	}
 	//Inherit from WorkerRunnerRefImpl
-	Object.setPrototypeOf(NodeWorkerRunnerRefImpl.prototype,
-		THREE.LoaderSupport.WorkerRunnerRefImpl);
+	Object.setPrototypeOf( NodeWorkerRunnerRefImpl.prototype, THREE.LoaderSupport.WorkerRunnerRefImpl );
 
 	/**
 	 * @inheritdoc
 	 * @memberOf THREE.LoaderSupport.NodeWorkerRunnerRefImpl
-	 * 
+	 *
 	 * @returns {MessagePort} NodeJS object that's similar to
 	 * GlobalWorkerScope
 	 */
 	NodeWorkerRunnerRefImpl.prototype.getParentScope = function(){
-		return _require("worker_threads").parentPort;
-	}
+		return _require( 'worker_threads' ).parentPort;
+	};
 
 	return NodeWorkerRunnerRefImpl;
 })();
 
-/**
- * This class provides the NodeJS implementation of LoaderWorker
- * @class
- * @extends THREE.LoaderSupport.LoaderWorker
- */
-THREE.LoaderSupport.NodeLoaderWorker = (function(){
-	function NodeLoaderWorker(){
-		LoaderWorker.call(this); //call super class
-	}
-	//Inherit from LoaderWorker
-	Object.setPrototypeOf(NodeLoaderWorker.prototype, LoaderWorker);
-
-	/**
-	 * @inheritdoc
-	 * @memberOf THREE.LoaderSupport.NodeLoaderWorker
-	 */
-	NodeLoaderWorker.checkSupport = function() {
-		try {
-			_require.resolve("worker_threads");
-		}
-		catch(e) {
-			return "This version of Node does not support web workers!";
-		}
-	}
-
-	/**
-	 * @inheritdoc
-	 * @memberOf THREE.LoaderSupport.NodeLoaderWorker
-	 */
-	NodeLoaderWorker.prototype.initWorker = function ( code, runnerImplName ) {
-		var supportError = NodeLoaderWorker.checkSupport();
-		if(supportError) {
-			throw supportError;
-		}
-			
-		this.runnerImplName = runnerImplName;
-
-		var Worker = _require("worker_threads").Worker;
-		this.worker = new Worker(code, {eval: true});
-
-		this.worker.onmessage = this._receiveWorkerMessage;
-
-		// set referemce to this, then processing in worker scope within "_receiveWorkerMessage" can access members
-		this.worker.runtimeRef = this;
-
-		// process stored queuedMessage
-		this._postMessage();
-	}
-
-	return NodeLoaderWorker;
-})();


### PR DESCRIPTION
This PR utilizes [the support that NodeJS added in `v10.5.0` for Workers](https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options) to allow `LoaderWorkerSupport` and subsequently `WWOBJLoader2` to run in a NodeJS environment.

- [x] Wrap all `window` usages in `if(typeof window !== "undefined")`
- [x] Add branch for NodeJS specific code for all `Worker` related code.
- [ ] Test it out in Nodejs environment
- [ ] Test it out in Webpack environment

Let me know if there's anything else you'd want me to add to this to fit the rest of the codebase!