### PR TITLE
Avoid window reference if absolute url is provided

### DIFF
--- a/packages/objloader2/src/OBJLoader2.ts
+++ b/packages/objloader2/src/OBJLoader2.ts
@@ -248,7 +248,12 @@ export class OBJLoader2 extends Loader {
         if (!url) {
             onError(new ErrorEvent('An invalid url was provided. Unable to continue!'));
         }
-        const urlFull = new URL(url, window.location.href).href;
+        let urlFull = '';
+        try {
+            urlFull = new URL(url).href;
+        } catch (error) {
+            urlFull = new URL(url, window.location.href).href;
+        }
         let filename = urlFull;
         const urlParts = urlFull.split('/');
         if (urlParts.length > 2) {


### PR DESCRIPTION
This should work as a small detour if an absolute URL is provided to the `load` method. Unfortunately `URL.canParse` [doesn't have wide support](https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static#browser_compatibility) so this not so elegant workaround is required. I don't think this would have any regressions for the existing functionality.

I also took a quick look through and this was the only `window` reference I saw